### PR TITLE
Fet/php upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ Looking for a modern hosting environment provisioned using Ansible? Check out [W
 
 ## Usage
 
+### PHP configuration
+
+The php-fpm pool configuration is located in `global/php-pool.conf` and defaults to PHP 7.1.  It will need modified if you want the default php-fpm pool service to be a different PHP version.  Additional PHP version upstream definitions can be added to the `/upstreams` folder (a PHP 7.0 sample is provided there).  You can either use the default pool using `$upstream` in your nginx configurations or the specific upstream definition (i.e. php71, php70) setup by your custom upstream definitions.
+
+For example, currently the nginx configuration for `singlesite.com` has the following set for php requests:
+
+```
+fastcgi_pass    $upstream
+```
+
+You could change that to the following to use the php 7.0 php service instead (assuming that php7.0-fpm service is running).
+
+```
+fastcgi_pass    php70
+```
+
+This effectively allows you to have different server blocks execute different versions of PHP if needed.
+
+### Site configuration
+
 You can use these sample configurations as reference or directly by replacing your existing nginx directory. Follow the steps below to replace your existing nginx configuration.
 
 Backup any existing config:

--- a/global/php-pool.conf
+++ b/global/php-pool.conf
@@ -1,0 +1,12 @@
+# Upstream to abstract backend connection(s) for PHP.
+# Additional upstreams can be added to /etc/nginx/upstreams/*.conf and then you just
+# change `default php71` to whatever the new upstream is (could be php70 for example).
+upstream php71 {
+    server unix:/run/php/php7.1-fpm.sock;
+}
+
+include /etc/nginx/upstreams/*.conf;
+
+map '' $upstream {
+    default php71;
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -33,7 +33,7 @@ http {
 	include global/limits.conf;
 
     # Some WP plugins that push large amounts of data via cookies
-    # can cause 500 HTTP erros if these values aren't increased.
+    # can cause 500 HTTP errors if these values aren't increased.
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;
 
@@ -43,6 +43,9 @@ http {
 
 	# Gzip
 	include global/gzip.conf;
+
+	# exposes configured php pool on $upstream variable
+	include global/php-pool.conf;
 
 	# Modules
 	include /etc/nginx/conf.d/*.conf;

--- a/sites-available/fastcgi-cache.com
+++ b/sites-available/fastcgi-cache.com
@@ -37,7 +37,7 @@ server {
 
 		# Use the php pool defined in the upstream variable.
 		# See global/php-pool.conf for definition.
-        fastcgi_pass   $upstream;
+		fastcgi_pass   $upstream;
 
 		# Skip cache based on rules in global/server/fastcgi-cache.conf.
 		fastcgi_cache_bypass $skip_cache;
@@ -50,8 +50,8 @@ server {
 		fastcgi_cache_valid 60m;
 	}
 
-    # Rewrite robots.txt
-    rewrite ^/robots.txt$ /index.php last;
+	# Rewrite robots.txt
+	rewrite ^/robots.txt$ /index.php last;
 
 	# Uncomment if using the fastcgi_cache_purge module and Nginx Helper plugin (https://wordpress.org/plugins/nginx-helper/)
 	# location ~ /purge(/.*) {

--- a/sites-available/fastcgi-cache.com
+++ b/sites-available/fastcgi-cache.com
@@ -35,10 +35,9 @@ server {
 		try_files $uri =404;
 		include global/fastcgi-params.conf;
 
-		# Change socket if using PHP pools or different PHP version
-		fastcgi_pass unix:/run/php/php7.1-fpm.sock;
-		#fastcgi_pass unix:/run/php/php7.0-fpm.sock;
-		#fastcgi_pass unix:/var/run/php5-fpm.sock;
+		# Use the php pool defined in the upstream variable.
+		# See global/php-pool.conf for definition.
+        fastcgi_pass   $upstream;
 
 		# Skip cache based on rules in global/server/fastcgi-cache.conf.
 		fastcgi_cache_bypass $skip_cache;

--- a/sites-available/multisite-subdirectory.com
+++ b/sites-available/multisite-subdirectory.com
@@ -31,12 +31,12 @@ server {
 		include global/fastcgi-params.conf;
 
 		# Use the php pool defined in the upstream variable.
-        # See global/php-pool.conf for definition.
-        fastcgi_pass   $upstream;
+		# See global/php-pool.conf for definition.
+		fastcgi_pass   $upstream;
 	}
 
-    # Rewrite robots.txt
-    rewrite ^/robots.txt$ /index.php last;
+	# Rewrite robots.txt
+	rewrite ^/robots.txt$ /index.php last;
 }
 
 # Redirect www to non-www

--- a/sites-available/multisite-subdirectory.com
+++ b/sites-available/multisite-subdirectory.com
@@ -30,10 +30,9 @@ server {
 		try_files $uri =404;
 		include global/fastcgi-params.conf;
 
-		# Change socket if using PHP pools or different PHP version
-        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
-        #fastcgi_pass unix:/run/php/php7.0-fpm.sock;
-        #fastcgi_pass unix:/var/run/php5-fpm.sock;
+		# Use the php pool defined in the upstream variable.
+        # See global/php-pool.conf for definition.
+        fastcgi_pass   $upstream;
 	}
 
     # Rewrite robots.txt

--- a/sites-available/multisite-subdomain.com
+++ b/sites-available/multisite-subdomain.com
@@ -28,12 +28,12 @@ server {
 		include global/fastcgi-params.conf;
 
 		# Use the php pool defined in the upstream variable.
-        # See global/php-pool.conf for definition.
-        fastcgi_pass   $upstream;
+		# See global/php-pool.conf for definition.
+		fastcgi_pass   $upstream;
 	}
 
-    # Rewrite robots.txt
-    rewrite ^/robots.txt$ /index.php last;
+	# Rewrite robots.txt
+	rewrite ^/robots.txt$ /index.php last;
 }
 
 # Redirect www to non-www

--- a/sites-available/multisite-subdomain.com
+++ b/sites-available/multisite-subdomain.com
@@ -27,10 +27,9 @@ server {
 		try_files $uri =404;
 		include global/fastcgi-params.conf;
 
-		# Change socket if using PHP pools or different PHP version
-        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
-        #fastcgi_pass unix:/run/php/php7.0-fpm.sock;
-        #fastcgi_pass unix:/var/run/php5-fpm.sock;
+		# Use the php pool defined in the upstream variable.
+        # See global/php-pool.conf for definition.
+        fastcgi_pass   $upstream;
 	}
 
     # Rewrite robots.txt

--- a/sites-available/singlesite.com
+++ b/sites-available/singlesite.com
@@ -28,12 +28,12 @@ server {
 		include global/fastcgi-params.conf;
 
 		# Use the php pool defined in the upstream variable.
-        # See global/php-pool.conf for definition.
-        fastcgi_pass   $upstream;
+		# See global/php-pool.conf for definition.
+		fastcgi_pass   $upstream;
 	}
 
-    # Rewrite robots.txt
-    rewrite ^/robots.txt$ /index.php last;
+	# Rewrite robots.txt
+	rewrite ^/robots.txt$ /index.php last;
 }
 
 # Redirect www to non-www

--- a/sites-available/singlesite.com
+++ b/sites-available/singlesite.com
@@ -27,10 +27,9 @@ server {
 		try_files $uri =404;
 		include global/fastcgi-params.conf;
 
-		# Change socket if using PHP pools or different PHP version
-        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
-        #fastcgi_pass unix:/run/php/php7.0-fpm.sock;
-        #fastcgi_pass unix:/var/run/php5-fpm.sock;
+		# Use the php pool defined in the upstream variable.
+        # See global/php-pool.conf for definition.
+        fastcgi_pass   $upstream;
 	}
 
     # Rewrite robots.txt

--- a/sites-available/ssl-fastcgi-cache.com
+++ b/sites-available/ssl-fastcgi-cache.com
@@ -16,7 +16,7 @@ server {
 
 	# Paths to certificate files.
 	ssl_certificate /etc/letsencrypt/live/ssl-fastcgi-cache.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/ssl-fastcgi-cache.com/privkey.pem;
+	ssl_certificate_key /etc/letsencrypt/live/ssl-fastcgi-cache.com/privkey.pem;
 
 	# File to be used as index
 	index index.php;
@@ -42,9 +42,9 @@ server {
 		try_files $uri =404;
 		include global/fastcgi-params.conf;
 
-        # Use the php pool defined in the upstream variable.
-        # See global/php-pool.conf for definition.
-        fastcgi_pass   $upstream;
+		# Use the php pool defined in the upstream variable.
+		# See global/php-pool.conf for definition.
+		fastcgi_pass   $upstream;
 
 		# Skip cache based on rules in global/server/fastcgi-cache.conf.
 		fastcgi_cache_bypass $skip_cache;
@@ -57,8 +57,8 @@ server {
 		fastcgi_cache_valid 60m;
 	}
 
-    # Rewrite robots.txt
-    rewrite ^/robots.txt$ /index.php last;
+	# Rewrite robots.txt
+	rewrite ^/robots.txt$ /index.php last;
 
 	# Uncomment if using the fastcgi_cache_purge module and Nginx Helper plugin (https://wordpress.org/plugins/nginx-helper/)
 	# location ~ /purge(/.*) {

--- a/sites-available/ssl-fastcgi-cache.com
+++ b/sites-available/ssl-fastcgi-cache.com
@@ -42,10 +42,9 @@ server {
 		try_files $uri =404;
 		include global/fastcgi-params.conf;
 
-		# Change socket if using PHP pools or different PHP version
-        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
-        #fastcgi_pass unix:/run/php/php7.0-fpm.sock;
-        #fastcgi_pass unix:/var/run/php5-fpm.sock;
+        # Use the php pool defined in the upstream variable.
+        # See global/php-pool.conf for definition.
+        fastcgi_pass   $upstream;
 
 		# Skip cache based on rules in global/server/fastcgi-cache.conf.
 		fastcgi_cache_bypass $skip_cache;

--- a/sites-available/ssl.com
+++ b/sites-available/ssl.com
@@ -10,8 +10,8 @@ server {
 	root /sites/ssl.com/public;
 
 	# Paths to certificate files.
-    ssl_certificate /etc/letsencrypt/live/ssl.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/ssl.com/privkey.pem;
+	ssl_certificate /etc/letsencrypt/live/ssl.com/fullchain.pem;
+	ssl_certificate_key /etc/letsencrypt/live/ssl.com/privkey.pem;
 
 	# File to be used as index
 	index index.php;

--- a/sites-available/ssl.com
+++ b/sites-available/ssl.com
@@ -34,14 +34,13 @@ server {
 		try_files $uri =404;
 		include global/fastcgi-params.conf;
 
-		# Change socket if using PHP pools or different PHP version
-        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
-        #fastcgi_pass unix:/run/php/php7.0-fpm.sock;
-        #fastcgi_pass unix:/var/run/php5-fpm.sock;
+		# Use the php pool defined in the upstream variable.
+		# See global/php-pool.conf for definition.
+		fastcgi_pass   $upstream;
 	}
 
-    # Rewrite robots.txt
-    rewrite ^/robots.txt$ /index.php last;
+	# Rewrite robots.txt
+	rewrite ^/robots.txt$ /index.php last;
 }
 
 # Redirect http to https

--- a/upstreams/php70.conf
+++ b/upstreams/php70.conf
@@ -1,0 +1,4 @@
+# Defines the upstream for PHP 7.0
+upstream php70 {
+    server unix:/run/php/php7.0-fpm.sock;
+}


### PR DESCRIPTION
This pull request breaks out the php upstream definition into its own separate configuration files.  This allows for all the sample configurations to share one default that can be overridden in one file as opposed to all sample files.  Makes for easier maintenance and automation tasks (ansible etc).