### PR TITLE
add letsencrypt challenge block for easier automation of letsencrypt cert setup

### DIFF
--- a/sites-available/singlesite.com
+++ b/sites-available/singlesite.com
@@ -19,6 +19,12 @@ server {
 	# Default server block rules
 	include global/server/defaults.conf;
 
+	# LetsEncrypt acme-challenge
+	location ^~ /.well-known/acme-challenge {
+        root /sites/letsencrypt/public;
+        try_files $uri $uri/ =404;
+    }
+
 	location / {
 		try_files $uri $uri/ /index.php?$args;
 	}


### PR DESCRIPTION
For automation of letsencrypt cert setup, this config will ensure that authentication of site existence/ownership is verified when letsencrypt issues its request challenge.