### PR TITLE
Cache webp files for 1 year too

### DIFF
--- a/global/server/static-files.conf
+++ b/global/server/static-files.conf
@@ -9,7 +9,7 @@ location ~* \.(?:rss|atom)$ {
 }
 
 # Caches images, icons, video, audio, HTC, etc.
-location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|mp4|ogg|ogv|webm|htc)$ {
+location ~* \.(?:jpg|jpeg|gif|png|webp|ico|cur|gz|svg|mp4|ogg|ogv|webm|htc)$ {
 	expires 1y;
 	access_log off;
 }


### PR DESCRIPTION
This PR adds `.webp` to the list of file extensions that gets cached for 1 year.