### PR TITLE
Add HTTP_HOST parameter to fastcgi-params.conf

### DIFF
--- a/global/fastcgi-params.conf
+++ b/global/fastcgi-params.conf
@@ -20,6 +20,7 @@ fastcgi_param  REMOTE_PORT        $remote_port;
 fastcgi_param  SERVER_ADDR        $server_addr;
 fastcgi_param  SERVER_PORT        $server_port;
 fastcgi_param  SERVER_NAME        $server_name;
+fastcgi_param  HTTP_HOST          $host;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;


### PR DESCRIPTION
Resolves https://github.com/spinupwp/wordpress-nginx/issues/39

Required to prevent malformed redirects when using HTTP/3. In brief, without this the host value gets malformed and leads to locations such as https:/// rather than the actual site URL.

Adding this header forces it to always exist and be accessible by PHP and WordPress.